### PR TITLE
Docs remove italics

### DIFF
--- a/docs/apps/services-instances.md
+++ b/docs/apps/services-instances.md
@@ -11,27 +11,27 @@ Serverless Cloud lets developers build in rapid iterations and aims to reduce th
 
 ## Services
 
-Serverless Cloud allows you to build **SERVICES** within your team's _ORGANIZATION_. You can create as many services as you want for different use cases or applications.
+Serverless Cloud allows you to build **SERVICES** within your team's **ORGANIZATION**. You can create as many services as you want for different use cases or applications.
 
 ## Using Instances
 
-Serverless Cloud provides the preview build of each service via instances. A service can have multiple instances and each _instance_ is completely separate from all the other _instances_ in a _service_, and even store their own copy of the data. The environments within _instances_ are identical, so you can ensure that your application will behave exactly the same across all of them.
+Serverless Cloud provides the preview build of each service via instances. A service can have multiple instances and each **instance** is completely separate from all the other **instances** in a **service**, and even store their own copy of the data. The environments within **instances** are identical, so you can ensure that your application will behave exactly the same across all of them.
 
-While _instance_ enviroments are identical, Serverless Cloud lets you classify instances to complement your workflow.
+While **instance** enviroments are identical, Serverless Cloud lets you classify instances to complement your workflow.
 
 ### Personal Instances
 
-Every developer on your team gets a **Personal Instance** for every **SERVICE** they work on. Each _Personal Instance_ is your own "personal development workspace" that automatically syncs and deploys changes from your local as you code. To enable this interactive development mode, type `cloud` into the CLI within your project directory. This will spin up your own personal instance on Cloud with your own data store. You'll be able to see the URL of your personal instance and detect the impact of changes you make. The logs for developer instance will start streaming instantly into your terminal to help you iterate quickly. Every change you make to your application, every static asset that you'll add under `/static` folder will be synced to your own personal instance under 5 seconds depending on the size of the change. 
+Every developer on your team gets a **Personal Instance** for every **SERVICE** they work on. Each **Personal Instance** is your own "personal development workspace" that automatically syncs and deploys changes from your local as you code. To enable this interactive development mode, type `cloud` into the CLI within your project directory. This will spin up your own personal instance on Cloud with your own data store. You'll be able to see the URL of your personal instance and detect the impact of changes you make. The logs for developer instance will start streaming instantly into your terminal to help you iterate quickly. Every change you make to your application, every static asset that you'll add under `/static` folder will be synced to your own personal instance under 5 seconds depending on the size of the change. 
 
 Note that the URL for personal instances won't be accessible after the personal development mode is ended. For this reason, it's encouraged to deploy your app to a stage. 
 
 ### Stages (Permanent Instances)
 
-When you're ready to show your work to the world, you can _deploy_ your code to a **stage**. These are permanent instances like `prod`, `staging` and `dev`. If you want to publish your code to one of these instances, type `cloud deploy my-stage-name` into the CLI and your **CODE** will be published to `my-stage-name`.
+When you're ready to show your work to the world, you can **deploy** your code to a **stage**. These are permanent instances like `prod`, `staging` and `dev`. If you want to publish your code to one of these instances, type `cloud deploy my-stage-name` into the CLI and your **CODE** will be published to `my-stage-name`.
 
 ### Previews (Ephemeral Instances)
 
-If you want to get feedback on your application, but don't yet want to publish it to one of the permanent stages above, you can created **PREVIEWS** instead. Type `cloud share` into the CLI, and Serverless Cloud will create a _preview_ that contains your **code AND data**. _Previews_ are just like _stages_, except that previews will automatically expire when they are no longer being used.
+If you want to get feedback on your application, but don't yet want to publish it to one of the permanent stages above, you can created **PREVIEWS** instead. Type `cloud share` into the CLI, and Serverless Cloud will create a **preview** that contains your **code AND data**. **Previews** are just like **stages**, except that previews will automatically expire when they are no longer being used.
 
 ### Test instances
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,15 +24,15 @@ Starts interactive development mode and runs your tests on Cloud. Enter `test` t
 
 ## `cloud share [NAME]`
 
-Deploys your **personal instance** _code AND data_ to a preview instance named `NAME`. If no `NAME` is provided, a unique name will be generated for you.
+Deploys your **personal instance** code AND data to a preview instance named `NAME`. If no `NAME` is provided, a unique name will be generated for you.
 
-A **preview instance** is an _ephermeral instance_ that you can use to easily share your work with your team. Preview instances allow you to create a stable snapshots of your current **personal instance** so that you can get feedback while continuing to make changes to your own version.
+A **preview instance** is an ephermeral instance that you can use to easily share your work with your team. Preview instances allow you to create a stable snapshots of your current **personal instance** so that you can get feedback while continuing to make changes to your own version.
 
 ## `cloud deploy [STAGE]`
 
-Deploys your **personal instance** _code_ to the provided `STAGE`. If no `STAGE` is provided, it will deploy to a `default` stage.
+Deploys your **personal instance** code to the provided `STAGE`. If no `STAGE` is provided, it will deploy to a `default` stage.
 
-A `STAGE` is a _long-lived instance_ or environment that hosts your service. Common names for `STAGE`s are `prod`, `staging`, `qa`, and `dev`.
+A `STAGE` is a long-lived instance or environment that hosts your service. Common names for `STAGE`s are `prod`, `staging`, `qa`, and `dev`.
 
 ## `cloud clone [SERVICE_NAME/INSTANCE_NAME] [--overwrite]`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,14 @@ menuText: Overview
 menuOrder: 1
 ---
 
-# Build _faster_ & _better_ with Serverless Cloud
+# Build faster & better with Serverless Cloud
 
 The cloud is immensely powerful, but also complex and filled with lots of moving parts. Developers are now wearing more hats than ever before, not only building and designing software, but becoming cloud architects that need to understand countless cloud services, scalable data engines, fault tolerance, and so much more. The goal of Serverless Cloud is to reduce this complexity by focusing on interpretation instead of configuration, and by automatically applying best practices to common use cases, removing the need for all the boilerplate and configuration, and allowing developers to do what they do best: build software.
 
 
 ## How it works
 
-Serverless Cloud lets you build scalable, highly-secure, pay-per-use applications, without needing a deep knowledge of cloud services with a familiar _Express.js-like_ API. Focus on writing code, instead of worrying about infrastructure. Using our lightweight command line tool, we monitor your local directory as you code, and then instanteously sync those changes to your own, fully-isolated **personal instance**, giving you a high-fidelity cloud environment to test updates in a rapid feedback loop. Plus, you have your own copy of Serverless Data to work with, letting you test your data-driven applications without affecting other team members or production instances. Build serverless workflows that gets triggered by API calls and/or capturing data events just by writing code. Serverless Cloud automatically takes care of spinning up the required infra that scales ultimately in the most efficient way.
+Serverless Cloud lets you build scalable, highly-secure, pay-per-use applications, without needing a deep knowledge of cloud services with a familiar Express.js-like API. Focus on writing code, instead of worrying about infrastructure. Using our lightweight command line tool, we monitor your local directory as you code, and then instanteously sync those changes to your own, fully-isolated **personal instance**, giving you a high-fidelity cloud environment to test updates in a rapid feedback loop. Plus, you have your own copy of Serverless Data to work with, letting you test your data-driven applications without affecting other team members or production instances. Build serverless workflows that gets triggered by API calls and/or capturing data events just by writing code. Serverless Cloud automatically takes care of spinning up the required infra that scales ultimately in the most efficient way.
 
 
 Jump to [Getting Started](/cloud/docs/getting-started)!

--- a/docs/workflows/cloning.md
+++ b/docs/workflows/cloning.md
@@ -7,7 +7,7 @@ parent: Worklows
 
 # Cloning Instances
 
-Another powerful feature of Serverless Cloud is its "forking" capabilities. _Developer Instances_ are just versatile working copies that can be used for developing, testing, debugging, and more. If you have an existing _git workflow_, you can load the current version of your code from your git repository. However, you can also **clone** an existing instance to give you a starting point. Type `cloud clone my-stage-name` into the CLI and it will copy both the **code AND data** from the `my-stage-name` instance into you _Developer Instance_ as well as update your local working directory. This allows you to quickly begin working with the current version of the code.
+Another powerful feature of Serverless Cloud is its "forking" capabilities. Developer Instances are just versatile working copies that can be used for developing, testing, debugging, and more. If you have an existing **git workflow**, you can load the current version of your code from your git repository. However, you can also **clone** an existing instance to give you a starting point. Type `cloud clone my-stage-name` into the CLI and it will copy both the **code AND data** from the `my-stage-name` instance into your Developer Instance as well as update your local working directory. This allows you to quickly begin working with the current version of the code.
 
 ```
 # An error is occuring at staging but you can't reproduce it on your personal instance. 

--- a/docs/workflows/preview-instances.md
+++ b/docs/workflows/preview-instances.md
@@ -7,7 +7,7 @@ parent: Worklows
 
 # Preview Instances 
 
-Preview Instances are used to share your work with your colleagues and with some stakeholders. Preview Instances are different than _Stages_ as it includes both code and data when spined up from your personal instance. 
+Preview Instances are used to share your work with your colleagues and with some stakeholders. Preview Instances are different than **Stages** as it includes both code and data when spined up from your personal instance. 
 
 ```
 # Share your project from Cloud Shell

--- a/docs/workflows/stages.md
+++ b/docs/workflows/stages.md
@@ -7,7 +7,7 @@ parent: Worklows
 
 # Stages
 
-When you're ready to show your work to the world, you can _deploy_ your code to a **stage**. These are permanent instances like `prod`, `staging` and `dev`. Deploying to a stage is achieved typing `deploy <stage-name>` on Cloud Shell and by typing `cloud deploy <stage-name>` from your terminal. This command will publish only the **CODE** to a permanent stage, creates a new stage if there's no stage with this name. 
+When you're ready to show your work to the world, you can **deploy** your code to a **stage**. These are permanent instances like `prod`, `staging` and `dev`. Deploying to a stage is achieved typing `deploy <stage-name>` on Cloud Shell and by typing `cloud deploy <stage-name>` from your terminal. This command will publish only the **CODE** to a permanent stage, creates a new stage if there's no stage with this name. 
 
 ```
 # Start your project from Cloud Shell


### PR DESCRIPTION
To further simplify the documentation we'd like to minimize the styling on all the content. One such case is the use of italics. In this PR I replaced `_` with `**` so we only have one means of emphasizing. This also helps with consistency, as well as appearance.