### PR TITLE
Fix typo: pong -> ping

### DIFF
--- a/examples/discord-spotify-playlister/index.ts
+++ b/examples/discord-spotify-playlister/index.ts
@@ -96,7 +96,7 @@ api.post('/discord', api.rawBody, verifyKeyMiddleware(params.DISCORD_PUBLIC_KEY)
 
   if (message.type === InteractionType.APPLICATION_COMMAND) {
     switch (commandName) {
-      case 'pong': {
+      case 'ping': {
         return reply('Pong')
       }
       case 'view': {


### PR DESCRIPTION
- [Example post](https://www.serverless.com/blog/making-a-discord-playlist-bot-with-serverless-cloud)
- There is a some error in original code!
   - with 'pong', I can't get valid response from discord bot
- So it should be changed to 'ping' 👍
- I think we should edit the blog post for the poor people, but I don't know how... 🥲