### PR TITLE
Add command to install serverless cloud

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -27,6 +27,7 @@ Here are the ways to get started with Serverless Cloud. These are:
 Serverless Cloud provides you with a rich set of templates that you can use to start developing against your personal sandbox. Just make sure you are navigated into an empty folder in your Terminal and you have [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm​​) installed. All you need to do is to run the following command to start with Serverless Cloud. 
 
 ```
+npm i -g @serverless/cloud
 npm init cloud
 ```
 


### PR DESCRIPTION
Install serverless cloud as a global package to be able to proceed with the cloud initialization.

Without an installation there was the following error on my Mac machine:
`/bin/sh: cloud: command not found`

In (the) future might be nice to be able to use [npx](https://docs.npmjs.com/cli/v8/commands/npx). With that, both steps are merged into one - more or less.
The best example for that optimization are classics like [create-react-app](https://create-react-app.dev/) to look at.